### PR TITLE
Fix PHP 7.4 deprecation: array/string curly braces access

### DIFF
--- a/Net/IDNA2.php
+++ b/Net/IDNA2.php
@@ -2683,7 +2683,7 @@ class Net_IDNA2
 
         if ($delim_pos > self::_byteLength($this->_punycode_prefix)) {
             for ($k = self::_byteLength($this->_punycode_prefix); $k < $delim_pos; ++$k) {
-                $decoded[] = ord($encoded{$k});
+                $decoded[] = ord($encoded[$k]);
             }
         } else {
             $decoded = array();
@@ -2700,7 +2700,7 @@ class Net_IDNA2
 
         for ($enco_idx = ($delim_pos)? ($delim_pos + 1) : 0; $enco_idx < $enco_len; ++$deco_len) {
             for ($old_idx = $idx, $w = 1, $k = $this->_base; 1 ; $k += $this->_base) {
-                $digit = $this->_decodeDigit($encoded{$enco_idx++});
+                $digit = $this->_decodeDigit($encoded[$enco_idx++]);
                 $idx += $digit * $w;
 
                 $t = ($k <= $bias) ?
@@ -3112,7 +3112,7 @@ class Net_IDNA2
         $mode = 'next';
         $test = 'none';
         for ($k = 0; $k < $inp_len; ++$k) {
-            $v = ord($input{$k}); // Extract byte from input string
+            $v = ord($input[$k]); // Extract byte from input string
 
             if ($v < 128) { // We found an ASCII char - put into string as is
                 $output[$out_len] = $v;
@@ -3279,7 +3279,7 @@ class Net_IDNA2
                 $out_len++;
                 $output[$out_len] = 0;
             }
-            $output[$out_len] += ord($input{$i}) << (8 * (3 - ($i % 4) ) );
+            $output[$out_len] += ord($input[$i]) << (8 * (3 - ($i % 4) ) );
         }
         return $output;
     }


### PR DESCRIPTION
Deprecated: Array and string offset access syntax with curly braces is deprecated

Hopefully these are all (or most) of them:
```
[Clover@Clover-NB rc]$ rg -tphp "(\\$|->|::)[A-Za-z0-9_]+\{"
vendor\pear\net_idna2\Net\IDNA2.php:2686:                $decoded[] = ord($encoded{$k});
vendor\pear\net_idna2\Net\IDNA2.php:2703:                $digit = $this->_decodeDigit($encoded{$enco_idx++});
vendor\pear\net_idna2\Net\IDNA2.php:3115:            $v = ord($input{$k}); // Extract byte from input string
vendor\pear\net_idna2\Net\IDNA2.php:3282:            $output[$out_len] += ord($input{$i}) << (8 * (3 - ($i % 4) ) );
```

https://github.com/php/php-src/blob/0e6e2297fcb27103cc5d550ee8434680ff1e879e/UPGRADING#L356-L357
